### PR TITLE
Remove `assets` special directory

### DIFF
--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -51,12 +51,6 @@ export default function amplify(): AstroIntegration {
           version: 1,
           routes: [
             {
-              path: `${_config.base}assets/*`,
-              target: {
-                kind: "Static",
-              },
-            },
-            {
               path: `${_config.base}*.*`,
               target: {
                 kind: "Static",


### PR DESCRIPTION
There's no more `assets` folder in Astro.

All the public assets are scaffolded right into the static directory with natural hierarchy.

<img width="247" alt="Screenshot 2024-03-27 at 9 29 23 PM" src="https://github.com/alexnguyennz/astro-aws-amplify/assets/46300090/5022d875-b2a2-445e-8fef-a548331931e7">
