### PR TITLE
load env automatically

### DIFF
--- a/.changeset/soft-chefs-accept.md
+++ b/.changeset/soft-chefs-accept.md
@@ -1,0 +1,5 @@
+---
+"astro-aws-amplify": minor
+---
+
+load environment variables automatically

--- a/packages/astro-aws-amplify/package.json
+++ b/packages/astro-aws-amplify/package.json
@@ -23,12 +23,9 @@
     ".": "./src/index.ts",
     "./server": "./src/server.ts"
   },
-  "peerDependencies": {
-    "astrojs-node-aws-amplify": "^7.0.1",
-    "astro": "^4.0.0"
-  },
   "dependencies": {
+    "astro": "^4.0.0",
     "astrojs-node-aws-amplify": "^7.0.1",
-    "astro": "^4.0.0"
+    "dotenv": "^16.4.5"
   }
 }

--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -4,11 +4,11 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export default function amplify(): AstroIntegration {
+export default function awsAmplify(): AstroIntegration {
   let _config: AstroConfig;
 
   return {
-    name: "astro-amplify",
+    name: "astro-aws-amplify",
     hooks: {
       "astro:config:setup": ({ config, updateConfig }) => {
         updateConfig({

--- a/packages/astro-aws-amplify/src/server.ts
+++ b/packages/astro-aws-amplify/src/server.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import type { SSRManifest } from "astro";
 import { NodeApp, applyPolyfills } from "astro/app/node";
 
@@ -5,6 +7,7 @@ import startServer from "astrojs-node-aws-amplify/standalone.js";
 import type { Options } from "astrojs-node-aws-amplify/types.js";
 
 applyPolyfills();
+
 export function createExports(manifest: SSRManifest, options: Options) {
   const app = new NodeApp(manifest);
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       astrojs-node-aws-amplify:
         specifier: ^7.0.1
         version: 7.0.1(astro@4.0.6)
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
 
   packages/docs:
     dependencies:
@@ -2503,6 +2506,11 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}


### PR DESCRIPTION
This PR introduces a way to automatically load the env variables from the AWS AMplify environment before it spins up the server.

The important thing here is to notice that even if someone did the steps of 

env >> .env
mv .env .amplify-hosting/compute/default/.env

the envs are NOT automatically loaded into the environment by the standalone server created by `astro-aws-amplify`

Hence, with dotenv, we make sure to load all the envs and make them accessible over import.meta.env and process.env.