### PR TITLE
chore: update compute runtime node version in deploy manifest

### DIFF
--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -78,7 +78,7 @@ export default function awsAmplify(): AstroIntegration {
             {
               name: "default",
               entrypoint: "entry.mjs",
-              runtime: "nodejs18.x",
+              runtime: "nodejs20.x",
             },
           ],
           framework: {


### PR DESCRIPTION
# Upgrade Node.js runtime from 18.x to 20.x

## Summary
Updates the AWS Amplify compute resource runtime from `nodejs18.x` to `nodejs20.x` to leverage the latest version with improved performance and security.

## Why this change?
- **AWS Recommendation**: AWS Amplify now recommends Node.js 20.x as the supported runtime version and will be deprecating Node.js 18.x from Sept 15. See Reference for documentation.

## Changes
- Updated `runtime` field in deploy manifest from `nodejs18.x` to `nodejs20.x`
- No breaking changes to existing functionality

## Impact
- Users will automatically benefit from improved performance and security
- Deployments will use the more stable and feature-rich Node.js 20.x runtime
- Future-proofs the adapter for upcoming AWS Amplify enhancements

## References
- [AWS Amplify Troubleshooting Guide](https://docs.aws.amazon.com/amplify/latest/userguide/troubleshooting-general.html#update-node-version)
- [Node.js 20.x LTS Release](https://nodejs.org/en/blog/release/v20.0.0)