### PR TITLE
add runtime option to awsAmplify function

### DIFF
--- a/demos/base-path/CHANGELOG.md
+++ b/demos/base-path/CHANGELOG.md
@@ -1,5 +1,12 @@
 # base-path
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies []:
+  - astro-aws-amplify@0.2.4
+
 ## 0.0.11
 
 ### Patch Changes

--- a/demos/base-path/package.json
+++ b/demos/base-path/package.json
@@ -2,7 +2,7 @@
   "name": "base-path",
   "type": "module",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/demos/blog/CHANGELOG.md
+++ b/demos/blog/CHANGELOG.md
@@ -1,5 +1,12 @@
 # blog
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies []:
+  - astro-aws-amplify@0.2.4
+
 ## 0.0.11
 
 ### Patch Changes

--- a/demos/blog/package.json
+++ b/demos/blog/package.json
@@ -2,7 +2,7 @@
   "name": "blog",
   "type": "module",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/demos/hybrid/CHANGELOG.md
+++ b/demos/hybrid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # hybrid
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies []:
+  - astro-aws-amplify@0.2.4
+
 ## 0.0.11
 
 ### Patch Changes

--- a/demos/hybrid/package.json
+++ b/demos/hybrid/package.json
@@ -2,7 +2,7 @@
   "name": "hybrid",
   "type": "module",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/astro-aws-amplify/CHANGELOG.md
+++ b/packages/astro-aws-amplify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # astro-aws-amplify
 
+## 0.2.4
+
+### Patch Changes
+
+- add runtime option to awsAmplify function
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/astro-aws-amplify/package.json
+++ b/packages/astro-aws-amplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-aws-amplify",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "description": "Deploy Astro to AWS Amplify (SSR)",
   "keywords": [

--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -4,8 +4,13 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export default function awsAmplify(): AstroIntegration {
+export interface AwsAmplifyOptions {
+  runtime?: string;
+}
+
+export default function awsAmplify(options: AwsAmplifyOptions = {}): AstroIntegration {
   let _config: AstroConfig;
+  const { runtime = "nodejs20.x" } = options;
 
   return {
     name: "astro-aws-amplify",
@@ -73,7 +78,7 @@ export default function awsAmplify(): AstroIntegration {
             {
               name: "default",
               entrypoint: "entry.mjs",
-              runtime: "nodejs20.x",
+              runtime,
             },
           ],
           framework: {


### PR DESCRIPTION
feat: add runtime option to awsAmplify function

- Introduced AwsAmplifyOptions interface to allow specifying a custom runtime.
- Updated awsAmplify function to accept options, defaulting to "nodejs20.x".
- Modified deploy manifest to use the runtime from options instead of a hardcoded value.