### PR TITLE
Generate Amplify customRules.json from Astro redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Unlike Vercel and Netlify, AWS Amplify Hosting does not auto-discover redirect r
 #### Option A — Amplify Console (one-time, manual)
 
 1. Open your app in the AWS Amplify Console.
-2. Go to **App settings → Rewrites and redirects**.
-3. Click **Open text editor**, paste the contents of `.amplify-hosting/customRules.json`, and save.
+2. Go to **Hosting → Rewrites and redirects**.
+3. Click **Manage rewrites and redirects**, paste the contents of `.amplify-hosting/customRules.json`, and save.
 
 #### Option B — `aws amplify update-app` (one-shot or scripted)
 
@@ -202,7 +202,7 @@ Set `AWS_APP_ID` as an Amplify environment variable, and attach an IAM policy al
 
 ### Status code mapping
 
-Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are folded onto these:
+Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are converted as follows:
 
 | Astro | Amplify |
 | ----- | ------- |
@@ -212,7 +212,7 @@ Amplify only supports `301` and `302` as redirect statuses, so Astro's other cod
 | `307` | `302`   |
 | `308` | `301`   |
 
-`301` and `302` map exactly. `303`, `307`, and `308` fold onto Amplify's nearest equivalent and emit a `warn`-level log at build time so the semantic difference is visible. Any other status code is skipped with a warning.
+`301` and `302` map exactly. `303`, `307`, and `308` emit a warning log at build time so the change is visible. Unknown status codes are also skipped with a warning.
 
 ### Dynamic params and spread routes
 
@@ -231,13 +231,13 @@ If your site is served under a `base` (`base: "/docs"` in `astro.config.mjs`), t
 
 Absolute URLs (`https://...`, `http://...`, or protocol-relative `//host/...`) are preserved verbatim in `target` and never base-prefixed.
 
-### Rule ordering
-
-Amplify evaluates `customRules` in declaration order — first match wins. The adapter sorts generated rules so more specific patterns come before generic ones (fewer wildcards first; longer literal prefixes break ties), preventing catch-alls from shadowing specific rules.
-
 ### Trailing slashes
 
 The adapter reads `config.trailingSlash` and aligns generated rules with the canonical URL shape: literal sources/targets get a `/` appended for `"always"`, stripped for `"never"`, and left as-is for `"ignore"` (the default). Wildcard endings (`/blog/<*>`), file-like paths (`/sitemap.xml`), and absolute URL targets (`https://...`) are never modified. Named placeholders (`/blog/<slug>`) are treated like literal segments and do receive the trailing-slash treatment.
+
+### Rule ordering
+
+Amplify evaluates `customRules` in declaration order — first match wins. The adapter sorts generated rules so more specific patterns come before generic ones (fewer wildcards first; longer literal prefixes break ties), preventing catch-alls from shadowing specific rules.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -126,118 +126,24 @@ frontend:
 
 ## Redirects
 
-Redirects defined in `astro.config.mjs` are translated into AWS Amplify "Rewrites and redirects" rules at build time and written to `.amplify-hosting/customRules.json`. The shape of that file matches the payload accepted by `aws amplify update-app --custom-rules`, so you can apply it to your Amplify app verbatim.
-
-### Declare redirects in your Astro config
+Redirects defined in your `astro.config.mjs` are translated into AWS Amplify "Rewrites and redirects" rules at build time and written to `.amplify-hosting/customRules.json`:
 
 ```js
 // astro.config.mjs
-import { defineConfig } from "astro/config";
-import awsAmplify from "astro-aws-amplify";
-
 export default defineConfig({
   output: "server",
   adapter: awsAmplify(),
   redirects: {
-    // Static redirect — defaults to 301 (permanent).
     "/old-page": "/new-page",
-    // Dynamic param with explicit status. Status options: 301, 302, 303, 307, 308.
     "/blog/[slug]": { status: 302, destination: "/posts/[slug]" },
-    // Spread / catch-all params are supported.
     "/docs/[...path]": "/help/[...path]",
   },
 });
 ```
 
-After `astro build` runs, `.amplify-hosting/customRules.json` will contain:
+After build, apply the generated file to your app via the Amplify Console, the AWS CLI (`aws amplify update-app --custom-rules`), or an `amplify.yml` postBuild step.
 
-```json
-[
-  { "source": "/old-page", "target": "/new-page", "status": "301" },
-  { "source": "/blog/<slug>", "target": "/posts/<slug>", "status": "302" },
-  { "source": "/docs/<*>", "target": "/help/<*>", "status": "301" }
-]
-```
-
-If your config has no `redirects` entries, the file is not written.
-
-### Apply the rules to your Amplify app
-
-Unlike Vercel and Netlify, AWS Amplify Hosting does not auto-discover redirect rules from a build artifact. You need to push the generated rules to the app once — pick whichever of these fits your workflow.
-
-#### Option A — Amplify Console (one-time, manual)
-
-1. Open your app in the AWS Amplify Console.
-2. Go to **Hosting → Rewrites and redirects**.
-3. Click **Manage rewrites and redirects**, paste the contents of `.amplify-hosting/customRules.json`, and save.
-
-#### Option B — `aws amplify update-app` (one-shot or scripted)
-
-```sh
-aws amplify update-app \
-  --app-id "$AWS_APP_ID" \
-  --custom-rules "$(cat .amplify-hosting/customRules.json)"
-```
-
-Requires `awscli` configured with credentials that have `amplify:UpdateApp` permission.
-
-#### Option C — `amplify.yml` postBuild step (continuous deployment)
-
-Add a `postBuild` step so every Amplify build pushes the latest rules:
-
-```yaml
-postBuild:
-  commands:
-    - |
-      if [ -f .amplify-hosting/customRules.json ]; then
-        aws amplify update-app \
-          --app-id "$AWS_APP_ID" \
-          --custom-rules "$(cat .amplify-hosting/customRules.json)"
-      fi
-```
-
-Set `AWS_APP_ID` as an Amplify environment variable, and attach an IAM policy allowing `amplify:UpdateApp` on the app's ARN to your Amplify service role.
-
-> **Heads up:** `update-app` with `--custom-rules` *replaces* the rule list. If you also manage rules in the Console, define them all in `astro.config.mjs` instead so the build is the single source of truth.
-
-### Status code mapping
-
-Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are converted as follows:
-
-| Astro | Amplify |
-| ----- | ------- |
-| `301` | `301`   |
-| `302` | `302`   |
-| `303` | `302`   |
-| `307` | `302`   |
-| `308` | `301`   |
-
-`301` and `302` map exactly. `303`, `307`, and `308` emit a warning log at build time so the change is visible. Unknown status codes are also skipped with a warning.
-
-### Dynamic params and spread routes
-
-Amplify supports two distinct placeholder constructs and the adapter maps each Astro segment to the right one:
-
-- `[param]` → `<param>` — named placeholder. The same name in `target` substitutes the captured segment, so `/old/[a]/[b]` → `/new/[a]/[b]` becomes `/old/<a>/<b>` → `/new/<a>/<b>`. Multiple named placeholders per rule are allowed.
-- `[...spread]` → `<*>` — greedy wildcard. Matches one or more segments and must appear at the end of the source as a single occurrence (a constraint Astro already satisfies, since spread is only allowed as the trailing segment).
-
-Mixed patterns like `/site/[lang]/[...rest]` translate to `/site/<lang>/<*>`.
-
-### Base paths
-
-If your site is served under a `base` (`base: "/docs"` in `astro.config.mjs`), the adapter automatically prefixes both `source` and `target` with the base. Write redirect keys/values relative to the site root — the prefixing is handled for you.
-
-### External destinations
-
-Absolute URLs (`https://...`, `http://...`, or protocol-relative `//host/...`) are preserved verbatim in `target` and never base-prefixed.
-
-### Trailing slashes
-
-The adapter reads `config.trailingSlash` and aligns generated rules with the canonical URL shape: literal sources/targets get a `/` appended for `"always"`, stripped for `"never"`, and left as-is for `"ignore"` (the default). Wildcard endings (`/blog/<*>`), file-like paths (`/sitemap.xml`), and absolute URL targets (`https://...`) are never modified. Named placeholders (`/blog/<slug>`) are treated like literal segments and do receive the trailing-slash treatment.
-
-### Rule ordering
-
-Amplify evaluates `customRules` in declaration order — first match wins. The adapter sorts generated rules so more specific patterns come before generic ones (fewer wildcards first; longer literal prefixes break ties), preventing catch-alls from shadowing specific rules.
+See the [package README](./packages/astro-aws-amplify/README.md#redirects) for the full reference — pattern syntax, status code mapping, base path and trailing-slash handling, rule ordering, and the apply workflow in detail.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ export default defineConfig({
 
 These are appended to `.amplify-hosting/customRules.json` verbatim, after the rules generated from `redirects`. Amplify evaluates rules in declaration order — first match wins — so a specific Astro redirect won't be shadowed by a catch-all rewrite declared here.
 
-Like the generated redirects, the file isn't picked up automatically — you'll need to apply it via one of the [three methods](#redirects) in the Redirects section.
+Like the generated redirects, the file isn't picked up automatically — you'll need to [apply it to your Amplify app](./packages/astro-aws-amplify/README.md#apply-the-rules-to-your-amplify-app) for the rules to take effect.
 
 See the [package README](./packages/astro-aws-amplify/README.md#custom-rules) for the full reference.
 
@@ -202,7 +202,7 @@ adapter: awsAmplify({
 }),
 ```
 
-Adjust the trailing slash on `source` and `target` to match your [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) setting — drop it for `"never"`, keep it for `"always"` and the default `"ignore"`. For sites served under a `base`, prefix accordingly (`/base/about/` → `/base/about/index.html`). Like every other entry in `customRules`, you'll need to apply the generated file to your Amplify app for these rewrites to take effect — see the [Redirects](#redirects) section above for the three available methods.
+Adjust the trailing slash on `source` and `target` to match your [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) setting — drop it for `"never"`, keep it for `"always"` and the default `"ignore"`. For sites served under a `base`, prefix accordingly (`/base/about/` → `/base/about/index.html`). Like every other entry in `customRules`, you'll need to [apply the generated file](./packages/astro-aws-amplify/README.md#apply-the-rules-to-your-amplify-app) to your Amplify app for these rewrites to take effect.
 
 The other option is to set up the same rules manually in the Amplify Console under **Hosting → Rewrites and redirects** — useful if you'd rather not put them in your Astro config or already manage Amplify rules outside of code.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,121 @@ frontend:
       - node_modules/**/*
 ```
 
+## Redirects
+
+Redirects defined in `astro.config.mjs` are translated into AWS Amplify "Rewrites and redirects" rules at build time and written to `.amplify-hosting/customRules.json`. The shape of that file matches the payload accepted by `aws amplify update-app --custom-rules`, so you can apply it to your Amplify app verbatim.
+
+### Declare redirects in your Astro config
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import awsAmplify from "astro-aws-amplify";
+
+export default defineConfig({
+  output: "server",
+  adapter: awsAmplify(),
+  redirects: {
+    // Static redirect — defaults to 301 (permanent).
+    "/old-page": "/new-page",
+    // Dynamic param with explicit status. Status options: 301, 302, 303, 307, 308.
+    "/blog/[slug]": { status: 302, destination: "/posts/[slug]" },
+    // Spread / catch-all params are supported.
+    "/docs/[...path]": "/help/[...path]",
+  },
+});
+```
+
+After `astro build` runs, `.amplify-hosting/customRules.json` will contain:
+
+```json
+[
+  { "source": "/old-page", "target": "/new-page", "status": "301" },
+  { "source": "/blog/<slug>", "target": "/posts/<slug>", "status": "302" },
+  { "source": "/docs/<*>", "target": "/help/<*>", "status": "301" }
+]
+```
+
+If your config has no `redirects` entries, the file is not written.
+
+### Apply the rules to your Amplify app
+
+Unlike Vercel and Netlify, AWS Amplify Hosting does not auto-discover redirect rules from a build artifact. You need to push the generated rules to the app once — pick whichever of these fits your workflow.
+
+#### Option A — Amplify Console (one-time, manual)
+
+1. Open your app in the AWS Amplify Console.
+2. Go to **App settings → Rewrites and redirects**.
+3. Click **Open text editor**, paste the contents of `.amplify-hosting/customRules.json`, and save.
+
+#### Option B — `aws amplify update-app` (one-shot or scripted)
+
+```sh
+aws amplify update-app \
+  --app-id "$AWS_APP_ID" \
+  --custom-rules "$(cat .amplify-hosting/customRules.json)"
+```
+
+Requires `awscli` configured with credentials that have `amplify:UpdateApp` permission.
+
+#### Option C — `amplify.yml` postBuild step (continuous deployment)
+
+Add a `postBuild` step so every Amplify build pushes the latest rules:
+
+```yaml
+postBuild:
+  commands:
+    - |
+      if [ -f .amplify-hosting/customRules.json ]; then
+        aws amplify update-app \
+          --app-id "$AWS_APP_ID" \
+          --custom-rules "$(cat .amplify-hosting/customRules.json)"
+      fi
+```
+
+Set `AWS_APP_ID` as an Amplify environment variable, and attach an IAM policy allowing `amplify:UpdateApp` on the app's ARN to your Amplify service role.
+
+> **Heads up:** `update-app` with `--custom-rules` *replaces* the rule list. If you also manage rules in the Console, define them all in `astro.config.mjs` instead so the build is the single source of truth.
+
+### Status code mapping
+
+Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are folded onto these:
+
+| Astro | Amplify |
+| ----- | ------- |
+| `301` | `301`   |
+| `302` | `302`   |
+| `303` | `302`   |
+| `307` | `302`   |
+| `308` | `301`   |
+
+`301` and `302` map exactly. `303`, `307`, and `308` fold onto Amplify's nearest equivalent and emit a `warn`-level log at build time so the semantic difference is visible. Any other status code is skipped with a warning.
+
+### Dynamic params and spread routes
+
+Amplify supports two distinct placeholder constructs and the adapter maps each Astro segment to the right one:
+
+- `[param]` → `<param>` — named placeholder. The same name in `target` substitutes the captured segment, so `/old/[a]/[b]` → `/new/[a]/[b]` becomes `/old/<a>/<b>` → `/new/<a>/<b>`. Multiple named placeholders per rule are allowed.
+- `[...spread]` → `<*>` — greedy wildcard. Matches one or more segments and must appear at the end of the source as a single occurrence (a constraint Astro already satisfies, since spread is only allowed as the trailing segment).
+
+Mixed patterns like `/site/[lang]/[...rest]` translate to `/site/<lang>/<*>`.
+
+### Base paths
+
+If your site is served under a `base` (`base: "/docs"` in `astro.config.mjs`), the adapter automatically prefixes both `source` and `target` with the base. Write redirect keys/values relative to the site root — the prefixing is handled for you.
+
+### External destinations
+
+Absolute URLs (`https://...`, `http://...`, or protocol-relative `//host/...`) are preserved verbatim in `target` and never base-prefixed.
+
+### Rule ordering
+
+Amplify evaluates `customRules` in declaration order — first match wins. The adapter sorts generated rules so more specific patterns come before generic ones (fewer wildcards first; longer literal prefixes break ties), preventing catch-alls from shadowing specific rules.
+
+### Trailing slashes
+
+The adapter reads `config.trailingSlash` and aligns generated rules with the canonical URL shape: literal sources/targets get a `/` appended for `"always"`, stripped for `"never"`, and left as-is for `"ignore"` (the default). Wildcard endings (`/blog/<*>`), file-like paths (`/sitemap.xml`), and absolute URL targets (`https://...`) are never modified. Named placeholders (`/blog/<slug>`) are treated like literal segments and do receive the trailing-slash treatment.
+
 ## Features
 
 ### Supported
@@ -131,6 +246,7 @@ frontend:
 - image optimization with [`<Image>`](https://docs.astro.build/en/guides/images/#image--astroassets) and [`<Picture />`](https://docs.astro.build/en/guides/images/#picture-)
 - [base paths](https://docs.astro.build/en/reference/configuration-reference/#base)
 - [middleware](https://docs.astro.build/en/guides/middleware/)
+- [redirects](#redirects) — auto-generated `customRules.json` from `astro.config.mjs`
 
 ### Unsupported or untested
 - [Amplify Image](https://docs.aws.amazon.com/amplify/latest/userguide/image-optimization.html) optimization

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ export default defineConfig({
 
 After build, apply the generated file to your app via the Amplify Console, the AWS CLI (`aws amplify update-app --custom-rules`), or an `amplify.yml` postBuild step.
 
-See the [package README](./packages/astro-aws-amplify/README.md#redirects) for the full reference — pattern syntax, status code mapping, base path and trailing-slash handling, rule ordering, and the apply workflow in detail.
+You can also pass platform-native rules (rewrites, API proxies, catch-all 404s) through a `customRules` option on the adapter — they're appended verbatim to the same file.
+
+See the [package README](./packages/astro-aws-amplify/README.md#redirects) for the full reference — pattern syntax, status code mapping, base path and trailing-slash handling, rule ordering, custom rules, and the apply workflow in detail.
 
 ## Features
 
@@ -163,7 +165,24 @@ See the [package README](./packages/astro-aws-amplify/README.md#redirects) for t
 
 ### Static or prerendered pages
 
-Static or prerendered pages (that are defined with `export const prerender = true`, or all pages by default when using `output: "static"`) will need a rewrite rule.
+Static or prerendered pages (defined with `export const prerender = true`, or all pages when using `output: "static"`) need a rewrite rule, since Amplify routes those paths to the SSR compute by default.
+
+The cleanest option is to declare these through the adapter's `customRules` option (see the [Redirects](#redirects) section), which keeps them in `astro.config.mjs` alongside the rest of your config:
+
+```js
+adapter: awsAmplify({
+  customRules: [
+    // Static page
+    { source: "/about/", target: "/about/index.html", status: "200" },
+    // Static dynamic route (e.g. /blog/[slug].astro)
+    { source: "/blog/<slug>/", target: "/blog/<slug>/index.html", status: "200" },
+  ],
+}),
+```
+
+Adjust the trailing slash on `source` and `target` to match your [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) setting — drop it for `"never"`, keep it for `"always"` and the default `"ignore"`. For sites served under a `base`, prefix accordingly (`/base/about/` → `/base/about/index.html`). Like every other entry in `customRules`, you'll need to apply the generated file to your Amplify app for these rewrites to take effect — see the [Redirects](#redirects) section above for the three available methods.
+
+The other option is to set up the same rules manually in the Amplify Console under **Hosting → Rewrites and redirects** — useful if you'd rather not put them in your Astro config or already manage Amplify rules outside of code.
 
 For example, if you have a static `/about` page, create a rewrite of:
 
@@ -183,8 +202,7 @@ For static dynamic routes, like a route of `/blog/[slug].astro`, create a rewrit
 /blog/<slug>/ /blog/<slug>/index.html 200 (Rewrite)
 ```
 
-
-#### Base path rewrites
+For sites served under a `base`:
 
 ```
 /base/about/ /base/about/index.html 200 (Rewrite)

--- a/README.md
+++ b/README.md
@@ -143,9 +143,30 @@ export default defineConfig({
 
 After build, apply the generated file to your app via the Amplify Console, the AWS CLI (`aws amplify update-app --custom-rules`), or an `amplify.yml` postBuild step.
 
-You can also pass platform-native rules (rewrites, API proxies, catch-all 404s) through a `customRules` option on the adapter — they're appended verbatim to the same file.
+See the [package README](./packages/astro-aws-amplify/README.md#redirects) for the full reference — pattern syntax, status code mapping, base path and trailing-slash handling, rule ordering, and the apply workflow in detail.
 
-See the [package README](./packages/astro-aws-amplify/README.md#redirects) for the full reference — pattern syntax, status code mapping, base path and trailing-slash handling, rule ordering, custom rules, and the apply workflow in detail.
+## Custom rules
+
+For anything that isn't a redirect — SPA-fallback rewrites, API proxies, catch-all 404s — pass Amplify rules through the adapter's `customRules` option:
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  output: "server",
+  adapter: awsAmplify({
+    customRules: [
+      { source: "/images/<*>", target: "https://images.example.com/<*>", status: "200" },
+      { source: "/<a>/", target: "/<a>/index.html", status: "200" },
+    ],
+  }),
+});
+```
+
+These are appended to `.amplify-hosting/customRules.json` verbatim, after the rules generated from `redirects`. Amplify evaluates rules in declaration order — first match wins — so a specific Astro redirect won't be shadowed by a catch-all rewrite declared here.
+
+Like the generated redirects, the file isn't picked up automatically — you'll need to apply it via one of the [three methods](#redirects) in the Redirects section.
+
+See the [package README](./packages/astro-aws-amplify/README.md#custom-rules) for the full reference.
 
 ## Features
 
@@ -155,6 +176,7 @@ See the [package README](./packages/astro-aws-amplify/README.md#redirects) for t
 - [base paths](https://docs.astro.build/en/reference/configuration-reference/#base)
 - [middleware](https://docs.astro.build/en/guides/middleware/)
 - [redirects](#redirects) — auto-generated `customRules.json` from `astro.config.mjs`
+- [custom rules](#custom-rules) — pass Amplify rewrites, proxies, and 404 fallbacks through the adapter
 
 ### Unsupported or untested
 - [Amplify Image](https://docs.aws.amazon.com/amplify/latest/userguide/image-optimization.html) optimization

--- a/demos/base-path/astro.config.mjs
+++ b/demos/base-path/astro.config.mjs
@@ -11,4 +11,11 @@ export default defineConfig({
   integrations: [mdx(), sitemap()],
   output: "server",
   adapter: awsAmplify(),
+  // Demonstrates the redirect → Amplify customRules pipeline together with
+  // the `base` config option. Both `source` and `target` are auto-prefixed
+  // with `/base/` in the generated `.amplify-hosting/customRules.json`.
+  redirects: {
+    "/old-page": "/new-page",
+    "/blog/[slug]": { status: 302, destination: "/posts/[slug]" },
+  },
 });

--- a/demos/server/astro.config.mjs
+++ b/demos/server/astro.config.mjs
@@ -12,9 +12,19 @@ export default defineConfig({
   },
   integrations: [mdx(), sitemap()],
   output: "server",
-  adapter: awsAmplify(),
-  // Demonstrates the redirect → Amplify customRules pipeline.
-  // After build, see `.amplify-hosting/customRules.json`.
+  // Demonstrates the redirect → Amplify customRules pipeline. Both the
+  // `redirects` field below and the `customRules` adapter option flow into
+  // `.amplify-hosting/customRules.json` after `astro build`.
+  adapter: awsAmplify({
+    customRules: [
+      // Rewrite for a specific prerendered page (status 200 = serve the
+      // target file without changing the URL in the browser).
+      { source: "/about/", target: "/about/index.html", status: "200" },
+      // Same pattern with a placeholder, covering any single-segment
+      // prerendered page (e.g. /contact/, /pricing/).
+      { source: "/<a>/", target: "/<a>/index.html", status: "200" },
+    ],
+  }),
   redirects: {
     // Static redirect (default 301).
     "/old-page": "/new-page",

--- a/demos/server/astro.config.mjs
+++ b/demos/server/astro.config.mjs
@@ -13,4 +13,17 @@ export default defineConfig({
   integrations: [mdx(), sitemap()],
   output: "server",
   adapter: awsAmplify(),
+  // Demonstrates the redirect → Amplify customRules pipeline.
+  // After build, see `.amplify-hosting/customRules.json`.
+  redirects: {
+    // Static redirect (default 301).
+    "/old-page": "/new-page",
+    // Dynamic param redirect with explicit status.
+    "/blog/[slug]": {
+      status: 302,
+      destination: "/posts/[slug]",
+    },
+    // Catch-all spread redirect.
+    "/docs/[...path]": "/help/[...path]",
+  },
 });

--- a/packages/astro-aws-amplify/CHANGELOG.md
+++ b/packages/astro-aws-amplify/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Minor Changes
 
 - Add support for redirects defined in `astro.config.mjs` — generates `.amplify-hosting/customRules.json` from your `redirects` config
-- Add a `customRules` adapter option for passing platform-native rules (rewrites, API proxies, 404 fallbacks) alongside the generated redirects
+- Add a `customRules` adapter option for passing Amplify rules (rewrites, API proxies, 404 fallbacks) alongside the generated redirects
 - Add an `astro-aws-amplify/redirects` subpath export for using the rule-building helpers outside `astro.config.mjs` (e.g., when sourcing redirects from a CMS)
 
 ## 0.3.0

--- a/packages/astro-aws-amplify/CHANGELOG.md
+++ b/packages/astro-aws-amplify/CHANGELOG.md
@@ -1,5 +1,12 @@
 # astro-aws-amplify
 
+## 0.4.0
+
+### Minor Changes
+
+- Add support for redirects defined in `astro.config.mjs` — generates `.amplify-hosting/customRules.json` from your `redirects` config
+- Expose `astro-aws-amplify/redirects` subpath export for composing custom rule pipelines
+
 ## 0.3.0
 
 ### Major Changes

--- a/packages/astro-aws-amplify/CHANGELOG.md
+++ b/packages/astro-aws-amplify/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Minor Changes
 
 - Add support for redirects defined in `astro.config.mjs` — generates `.amplify-hosting/customRules.json` from your `redirects` config
-- Expose `astro-aws-amplify/redirects` subpath export for composing custom rule pipelines
+- Add a `customRules` adapter option for passing platform-native rules (rewrites, API proxies, 404 fallbacks) alongside the generated redirects
+- Add an `astro-aws-amplify/redirects` subpath export for using the rule-building helpers outside `astro.config.mjs` (e.g., when sourcing redirects from a CMS)
 
 ## 0.3.0
 

--- a/packages/astro-aws-amplify/README.md
+++ b/packages/astro-aws-amplify/README.md
@@ -258,7 +258,7 @@ Amplify evaluates `customRules` in declaration order — the first match wins. T
 
 ## Custom rules
 
-Astro's `redirects` config only models redirects. For anything else Amplify supports — SPA-fallback rewrites, API proxies, catch-all 404s, region-conditional rules — pass platform-native rules through the adapter's `customRules` option:
+Astro's `redirects` config only models redirects. For anything else Amplify supports — SPA-fallback rewrites, API proxies, catch-all 404s, region-conditional rules — pass them through the adapter's `customRules` option:
 
 ```js
 // astro.config.mjs
@@ -278,17 +278,17 @@ export default defineConfig({
 });
 ```
 
-Rules from `customRules` are written to `.amplify-hosting/customRules.json` verbatim, **after** the rules generated from `redirects`. That ordering matters: Amplify evaluates rules first-match-wins, so a specific Astro-config redirect like `/old-marketing` → `/products/foo` will fire before a generic catch-all rewrite declared here.
+These are appended to `.amplify-hosting/customRules.json` verbatim, after the rules generated from `redirects`. Amplify evaluates rules in declaration order — first match wins — so a specific Astro redirect won't be shadowed by a catch-all rewrite declared here.
 
-The option accepts the same `AmplifyCustomRule` shape Amplify's API expects (`{ source, target, status, condition? }`), so anything you'd write into the Amplify Console's "Rewrites and redirects" editor or push with `aws amplify update-app --custom-rules` works here. Status values are `"200"` (rewrite), `"301"`, `"302"`, `"404"`, or `"404-200"`.
+Like the generated redirects, the file isn't picked up automatically — you'll need to [apply it to your Amplify app](#apply-the-rules-to-your-amplify-app) for the rules to take effect.
 
-The type is re-exported for convenience:
+The option accepts the `AmplifyCustomRule` shape Amplify's API expects (`{ source, target, status, condition? }`), so anything you'd write in the Amplify Console or push via `aws amplify update-app --custom-rules` works here. Status values are `"200"` (rewrite), `"301"`, `"302"`, `"404"`, or `"404-200"`. The type is re-exported from the main entry for convenience:
 
 ```ts
 import type { AmplifyCustomRule } from "astro-aws-amplify";
 
 const rules: AmplifyCustomRule[] = [
-  { source: "/api/<*>", target: "/api/<*>", status: "200" },
+  { source: "/<a>/", target: "/<a>/index.html", status: "200" },
 ];
 ```
 
@@ -300,7 +300,7 @@ const rules: AmplifyCustomRule[] = [
 - [base paths](https://docs.astro.build/en/reference/configuration-reference/#base)
 - [middleware](https://docs.astro.build/en/guides/middleware/)
 - [redirects](#redirects) — auto-generated `customRules.json` from `astro.config.mjs`
-- [custom rules](#custom-rules) — pass platform-native rewrites, proxies, and 404 fallbacks through the adapter
+- [custom rules](#custom-rules) — pass Amplify rewrites, proxies, and 404 fallbacks through the adapter
 
 ### Unsupported or untested
 - [Amplify Image](https://docs.aws.amazon.com/amplify/latest/userguide/image-optimization.html) optimization

--- a/packages/astro-aws-amplify/README.md
+++ b/packages/astro-aws-amplify/README.md
@@ -256,6 +256,42 @@ Wildcard endings (`/blog/<*>`) are left alone in every mode because Amplify's `<
 
 Amplify evaluates `customRules` in declaration order — the first match wins. The adapter sorts the generated rules so more specific patterns come before generic ones (rules with fewer wildcards first; longer literal prefixes break ties). That keeps a generic catch-all like `/[...all]` from accidentally swallowing a specific `/blog/[slug]` redirect declared on the same site.
 
+## Custom rules
+
+Astro's `redirects` config only models redirects. For anything else Amplify supports — SPA-fallback rewrites, API proxies, catch-all 404s, region-conditional rules — pass platform-native rules through the adapter's `customRules` option:
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import awsAmplify from "astro-aws-amplify";
+
+export default defineConfig({
+  output: "server",
+  adapter: awsAmplify({
+    customRules: [
+      // Reverse proxy — serve another origin's content under the same URL.
+      { source: "/images/<*>", target: "https://images.example.com/<*>", status: "200" },
+      // SPA-style fallback for prerendered directory pages.
+      { source: "/<a>/", target: "/<a>/index.html", status: "200" },
+    ],
+  }),
+});
+```
+
+Rules from `customRules` are written to `.amplify-hosting/customRules.json` verbatim, **after** the rules generated from `redirects`. That ordering matters: Amplify evaluates rules first-match-wins, so a specific Astro-config redirect like `/old-marketing` → `/products/foo` will fire before a generic catch-all rewrite declared here.
+
+The option accepts the same `AmplifyCustomRule` shape Amplify's API expects (`{ source, target, status, condition? }`), so anything you'd write into the Amplify Console's "Rewrites and redirects" editor or push with `aws amplify update-app --custom-rules` works here. Status values are `"200"` (rewrite), `"301"`, `"302"`, `"404"`, or `"404-200"`.
+
+The type is re-exported for convenience:
+
+```ts
+import type { AmplifyCustomRule } from "astro-aws-amplify";
+
+const rules: AmplifyCustomRule[] = [
+  { source: "/api/<*>", target: "/api/<*>", status: "200" },
+];
+```
+
 ## Features
 
 ### Supported
@@ -264,6 +300,7 @@ Amplify evaluates `customRules` in declaration order — the first match wins. T
 - [base paths](https://docs.astro.build/en/reference/configuration-reference/#base)
 - [middleware](https://docs.astro.build/en/guides/middleware/)
 - [redirects](#redirects) — auto-generated `customRules.json` from `astro.config.mjs`
+- [custom rules](#custom-rules) — pass platform-native rewrites, proxies, and 404 fallbacks through the adapter
 
 ### Unsupported or untested
 - [Amplify Image](https://docs.aws.amazon.com/amplify/latest/userguide/image-optimization.html) optimization
@@ -274,7 +311,24 @@ Amplify evaluates `customRules` in declaration order — the first match wins. T
 
 ### Static or prerendered pages
 
-Static or prerendered pages (that are defined with `export const prerender = true`, or all pages by default when using `output: "static"`) will need a rewrite rule.
+Static or prerendered pages (defined with `export const prerender = true`, or all pages when using `output: "static"`) need a rewrite rule, since Amplify routes those paths to the SSR compute by default.
+
+The cleanest option is to declare these through the adapter's [`customRules`](#custom-rules) option, which keeps them in `astro.config.mjs` alongside the rest of your config:
+
+```js
+adapter: awsAmplify({
+  customRules: [
+    // Static page
+    { source: "/about/", target: "/about/index.html", status: "200" },
+    // Static dynamic route (e.g. /blog/[slug].astro)
+    { source: "/blog/<slug>/", target: "/blog/<slug>/index.html", status: "200" },
+  ],
+}),
+```
+
+Adjust the trailing slash on `source` and `target` to match your [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) setting — drop it for `"never"`, keep it for `"always"` and the default `"ignore"`. For sites served under a `base`, prefix accordingly (`/base/about/` → `/base/about/index.html`). Like every other entry in `customRules`, you'll need to [apply the generated file](#apply-the-rules-to-your-amplify-app) to your Amplify app for these rewrites to take effect.
+
+The other option is to set up the same rules manually in the Amplify Console under **Hosting → Rewrites and redirects** — useful if you'd rather not put them in your Astro config or already manage Amplify rules outside of code.
 
 For example, if you have a static `/about` page, create a rewrite of:
 
@@ -294,8 +348,7 @@ For static dynamic routes, like a route of `/blog/[slug].astro`, create a rewrit
 /blog/<slug>/ /blog/<slug>/index.html 200 (Rewrite)
 ```
 
-
-#### Base path rewrites
+For sites served under a `base`:
 
 ```
 /base/about/ /base/about/index.html 200 (Rewrite)

--- a/packages/astro-aws-amplify/README.md
+++ b/packages/astro-aws-amplify/README.md
@@ -161,8 +161,8 @@ Unlike Vercel and Netlify, AWS Amplify Hosting does not auto-discover redirect r
 #### Option A — Amplify Console (one-time, manual)
 
 1. Open your app in the AWS Amplify Console.
-2. Go to **App settings → Rewrites and redirects**.
-3. Click **Open text editor**, paste the contents of `.amplify-hosting/customRules.json`, and save.
+2. Go to **Hosting → Rewrites and redirects**.
+3. Click **Manage rewrites and redirects**, paste the contents of `.amplify-hosting/customRules.json`, and save.
 
 This is the simplest path if your redirects rarely change.
 
@@ -213,7 +213,7 @@ Set `AWS_APP_ID` as an Amplify environment variable, and attach an IAM policy al
 
 ### Status code mapping
 
-Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are folded onto these:
+Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are converted as follows:
 
 | Astro | Amplify |
 | ----- | ------- |
@@ -223,7 +223,7 @@ Amplify only supports `301` and `302` as redirect statuses, so Astro's other cod
 | `307` | `302`   |
 | `308` | `301`   |
 
-`301` and `302` map exactly. `303`, `307`, and `308` fold onto Amplify's nearest equivalent and emit a `warn`-level log at build time so the semantic difference is visible. Any other status code is skipped with a warning.
+`301` and `302` map exactly. `303`, `307`, and `308` emit a warning log at build time so the change is visible. Unknown status codes are also skipped with a warning.
 
 ### Dynamic params and spread routes
 
@@ -242,10 +242,6 @@ If your site is served under a `base` (`base: "/docs"` in `astro.config.mjs`), t
 
 Absolute URLs (`https://...`, `http://...`, or protocol-relative `//host/...`) are preserved verbatim in `target` and never base-prefixed, so `"/external": "https://example.com/page"` lands in `customRules.json` exactly as written.
 
-### Rule ordering
-
-Amplify evaluates `customRules` in declaration order — the first match wins. The adapter sorts the generated rules so more specific patterns come before generic ones (rules with fewer wildcards first; longer literal prefixes break ties). That keeps a generic catch-all like `/[...all]` from accidentally swallowing a specific `/blog/[slug]` redirect declared on the same site.
-
 ### Trailing slashes
 
 The adapter reads `config.trailingSlash` and brings the generated rules into line with the canonical URL shape, so the edge handles the redirect without falling through to SSR:
@@ -255,6 +251,10 @@ The adapter reads `config.trailingSlash` and brings the generated rules into lin
 - `"ignore"` (default) — sources and targets are emitted as written.
 
 Wildcard endings (`/blog/<*>`) are left alone in every mode because Amplify's `<*>` is greedy and matches both `/blog/foo` and `/blog/foo/` from a single rule. Paths that look like static files (`/sitemap.xml`) and absolute URL targets (`https://...`) are also left untouched. Named placeholders (`/blog/<slug>`) are treated like literal segments and do receive the trailing-slash treatment.
+
+### Rule ordering
+
+Amplify evaluates `customRules` in declaration order — the first match wins. The adapter sorts the generated rules so more specific patterns come before generic ones (rules with fewer wildcards first; longer literal prefixes break ties). That keeps a generic catch-all like `/[...all]` from accidentally swallowing a specific `/blog/[slug]` redirect declared on the same site.
 
 ## Features
 

--- a/packages/astro-aws-amplify/README.md
+++ b/packages/astro-aws-amplify/README.md
@@ -117,6 +117,145 @@ frontend:
       - node_modules/**/*
 ```
 
+## Redirects
+
+Redirects defined in `astro.config.mjs` are translated into AWS Amplify "Rewrites and redirects" rules at build time and written to `.amplify-hosting/customRules.json`. The shape of that file matches the payload accepted by `aws amplify update-app --custom-rules`, so you can apply it to your Amplify app verbatim.
+
+### Declare redirects in your Astro config
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import awsAmplify from "astro-aws-amplify";
+
+export default defineConfig({
+  output: "server",
+  adapter: awsAmplify(),
+  redirects: {
+    // Static redirect — defaults to 301 (permanent).
+    "/old-page": "/new-page",
+    // Dynamic param with explicit status. Status options: 301, 302, 303, 307, 308.
+    "/blog/[slug]": { status: 302, destination: "/posts/[slug]" },
+    // Spread / catch-all params are supported.
+    "/docs/[...path]": "/help/[...path]",
+  },
+});
+```
+
+After `astro build` runs, `.amplify-hosting/customRules.json` will contain:
+
+```json
+[
+  { "source": "/old-page", "target": "/new-page", "status": "301" },
+  { "source": "/blog/<slug>", "target": "/posts/<slug>", "status": "302" },
+  { "source": "/docs/<*>", "target": "/help/<*>", "status": "301" }
+]
+```
+
+If your config has no `redirects` entries, the file is not written.
+
+### Apply the rules to your Amplify app
+
+Unlike Vercel and Netlify, AWS Amplify Hosting does not auto-discover redirect rules from a build artifact. You need to push the generated rules to the app once — pick whichever of these fits your workflow.
+
+#### Option A — Amplify Console (one-time, manual)
+
+1. Open your app in the AWS Amplify Console.
+2. Go to **App settings → Rewrites and redirects**.
+3. Click **Open text editor**, paste the contents of `.amplify-hosting/customRules.json`, and save.
+
+This is the simplest path if your redirects rarely change.
+
+#### Option B — `aws amplify update-app` (one-shot or scripted)
+
+Run locally or in CI after a build:
+
+```sh
+aws amplify update-app \
+  --app-id "$AWS_APP_ID" \
+  --custom-rules "$(cat .amplify-hosting/customRules.json)"
+```
+
+Requires `awscli` configured with credentials that have `amplify:UpdateApp` permission.
+
+#### Option C — `amplify.yml` postBuild step (continuous deployment)
+
+Add a `postBuild` step so every Amplify build pushes the latest rules:
+
+```yaml
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci
+    build:
+      commands:
+        - npm run build
+        - mv node_modules ./.amplify-hosting/compute/default
+    postBuild:
+      commands:
+        - |
+          if [ -f .amplify-hosting/customRules.json ]; then
+            aws amplify update-app \
+              --app-id "$AWS_APP_ID" \
+              --custom-rules "$(cat .amplify-hosting/customRules.json)"
+          fi
+  artifacts:
+    baseDirectory: .amplify-hosting
+    files:
+      - "**/*"
+```
+
+Set `AWS_APP_ID` as an Amplify environment variable, and attach an IAM policy allowing `amplify:UpdateApp` on the app's ARN to your Amplify service role.
+
+> **Heads up:** `update-app` with `--custom-rules` *replaces* the rule list. If you also manage rules in the Console, define them all in `astro.config.mjs` instead so the build is the single source of truth.
+
+### Status code mapping
+
+Amplify only supports `301` and `302` as redirect statuses, so Astro's other codes are folded onto these:
+
+| Astro | Amplify |
+| ----- | ------- |
+| `301` | `301`   |
+| `302` | `302`   |
+| `303` | `302`   |
+| `307` | `302`   |
+| `308` | `301`   |
+
+`301` and `302` map exactly. `303`, `307`, and `308` fold onto Amplify's nearest equivalent and emit a `warn`-level log at build time so the semantic difference is visible. Any other status code is skipped with a warning.
+
+### Dynamic params and spread routes
+
+Amplify supports two distinct placeholder constructs and the adapter maps each Astro segment to the right one:
+
+- `[param]` → `<param>` — Amplify's named placeholder. The same name in `target` substitutes the captured segment, so `/old/[a]/[b]` → `/new/[a]/[b]` becomes `/old/<a>/<b>` → `/new/<a>/<b>`. Multiple named placeholders per rule are allowed.
+- `[...spread]` → `<*>` — Amplify's greedy wildcard. It matches one or more path segments and is restricted to a single occurrence at the end of the source. Astro only allows `[...spread]` as the trailing segment of a route, so this restriction is satisfied automatically.
+
+Mixed patterns like `/site/[lang]/[...rest]` translate to `/site/<lang>/<*>`, combining a named placeholder with the trailing wildcard.
+
+### Base paths
+
+If your site is served under a `base` (`base: "/docs"` in `astro.config.mjs`), the adapter automatically prefixes both `source` and `target` with the base, so a redirect declared as `/old` → `/new` becomes `/docs/old` → `/docs/new` in `customRules.json`. Write your redirect keys/values relative to the site root the same way you do everywhere else in Astro — the prefixing is handled for you.
+
+### External destinations
+
+Absolute URLs (`https://...`, `http://...`, or protocol-relative `//host/...`) are preserved verbatim in `target` and never base-prefixed, so `"/external": "https://example.com/page"` lands in `customRules.json` exactly as written.
+
+### Rule ordering
+
+Amplify evaluates `customRules` in declaration order — the first match wins. The adapter sorts the generated rules so more specific patterns come before generic ones (rules with fewer wildcards first; longer literal prefixes break ties). That keeps a generic catch-all like `/[...all]` from accidentally swallowing a specific `/blog/[slug]` redirect declared on the same site.
+
+### Trailing slashes
+
+The adapter reads `config.trailingSlash` and brings the generated rules into line with the canonical URL shape, so the edge handles the redirect without falling through to SSR:
+
+- `"always"` — literal sources and targets get a `/` appended (`/old-page/`, `/posts/[slug]/`).
+- `"never"` — any trailing slash is stripped.
+- `"ignore"` (default) — sources and targets are emitted as written.
+
+Wildcard endings (`/blog/<*>`) are left alone in every mode because Amplify's `<*>` is greedy and matches both `/blog/foo` and `/blog/foo/` from a single rule. Paths that look like static files (`/sitemap.xml`) and absolute URL targets (`https://...`) are also left untouched. Named placeholders (`/blog/<slug>`) are treated like literal segments and do receive the trailing-slash treatment.
+
 ## Features
 
 ### Supported
@@ -124,6 +263,7 @@ frontend:
 - image optimization with [`<Image>`](https://docs.astro.build/en/guides/images/#image--astroassets) and [`<Picture />`](https://docs.astro.build/en/guides/images/#picture-)
 - [base paths](https://docs.astro.build/en/reference/configuration-reference/#base)
 - [middleware](https://docs.astro.build/en/guides/middleware/)
+- [redirects](#redirects) — auto-generated `customRules.json` from `astro.config.mjs`
 
 ### Unsupported or untested
 - [Amplify Image](https://docs.aws.amazon.com/amplify/latest/userguide/image-optimization.html) optimization

--- a/packages/astro-aws-amplify/package.json
+++ b/packages/astro-aws-amplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-aws-amplify",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "Deploy Astro to AWS Amplify (SSR)",
   "keywords": [
@@ -21,7 +21,8 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./server": "./src/server.ts"
+    "./server": "./src/server.ts",
+    "./redirects": "./src/redirects.ts"
   },
   "peerDependencies": {
     "astro": "^6.0.0"

--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -1,15 +1,29 @@
-import type { AstroConfig, AstroIntegration } from "astro";
+import type {
+  AstroConfig,
+  AstroIntegration,
+  IntegrationResolvedRoute,
+} from "astro";
 
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { buildCustomRules } from "./redirects.js";
+
 export interface AwsAmplifyOptions {
+  /**
+   * Node.js runtime to declare in the SSR `deploy-manifest.json`.
+   *
+   * Defaults to `"nodejs22.x"`. Must be a runtime supported by Amplify Hosting.
+   */
   runtime?: string;
 }
 
-export default function awsAmplify(options: AwsAmplifyOptions = {}): AstroIntegration {
+export default function awsAmplify(
+  options: AwsAmplifyOptions = {},
+): AstroIntegration {
   let _config: AstroConfig;
+  let _routes: IntegrationResolvedRoute[] = [];
   const { runtime = "nodejs22.x" } = options;
 
   return {
@@ -42,7 +56,12 @@ export default function awsAmplify(options: AwsAmplifyOptions = {}): AstroIntegr
 
         _config = config;
       },
-      "astro:build:done": async () => {
+      "astro:routes:resolved": ({ routes }) => {
+        // Captured for `astro:build:done`, where we translate redirect routes
+        // into Amplify's customRules format.
+        _routes = routes;
+      },
+      "astro:build:done": async ({ logger }) => {
         const deployManifestConfig = {
           version: 1,
           routes: [
@@ -83,14 +102,42 @@ export default function awsAmplify(options: AwsAmplifyOptions = {}): AstroIntegr
           },
         };
 
-        const functionsConfigPath = join(
+        const amplifyHostingDir = join(
           fileURLToPath(_config.root),
-          "/.amplify-hosting/deploy-manifest.json",
+          ".amplify-hosting",
         );
+
         await writeFile(
-          functionsConfigPath,
+          join(amplifyHostingDir, "deploy-manifest.json"),
           JSON.stringify(deployManifestConfig),
         );
+
+        // Translate `redirects` from astro.config.mjs into Amplify's
+        // customRules format. Amplify Hosting does not auto-discover redirect
+        // rules from a build artifact the way Vercel/Netlify do, so this file
+        // is meant to be applied to the app via the Amplify Console, the AWS
+        // CLI, or an `amplify.yml` postBuild step. See the README "Redirects"
+        // section for the full deployment workflow.
+        //
+        // Skipped when there are no redirects so builds don't emit an empty
+        // config alongside the rest of the artifact tree.
+        const customRules = buildCustomRules(
+          _routes,
+          _config.base,
+          _config.trailingSlash,
+          logger,
+        );
+        if (customRules.length > 0) {
+          await writeFile(
+            join(amplifyHostingDir, "customRules.json"),
+            JSON.stringify(customRules, null, 2) + "\n",
+          );
+          logger.info(
+            `Generated ${customRules.length} Amplify custom rule${
+              customRules.length === 1 ? "" : "s"
+            } → .amplify-hosting/customRules.json`,
+          );
+        }
       },
     },
   };

--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -8,7 +8,13 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { AmplifyCustomRule } from "./redirects.js";
 import { buildCustomRules } from "./redirects.js";
+
+export type {
+  AmplifyCustomRule,
+  AmplifyRedirectStatus,
+} from "./redirects.js";
 
 export interface AwsAmplifyOptions {
   /**
@@ -17,6 +23,18 @@ export interface AwsAmplifyOptions {
    * Defaults to `"nodejs22.x"`. Must be a runtime supported by Amplify Hosting.
    */
   runtime?: string;
+
+  /**
+   * Extra Amplify custom rules appended verbatim after the rules generated
+   * from `astro.config.mjs`'s `redirects` field. Use these for SPA-fallback
+   * rewrites, API proxies, catch-all 404s, or anything else Astro's
+   * `redirects` field doesn't model.
+   *
+   * Rules are emitted in declaration order, after the (specificity-sorted)
+   * generated redirects. That ordering means a generic catch-all rewrite
+   * here won't shadow a specific redirect from `astro.config.mjs`.
+   */
+  customRules?: AmplifyCustomRule[];
 }
 
 export default function awsAmplify(
@@ -113,29 +131,42 @@ export default function awsAmplify(
         );
 
         // Translate `redirects` from astro.config.mjs into Amplify's
-        // customRules format. Amplify Hosting does not auto-discover redirect
-        // rules from a build artifact the way Vercel/Netlify do, so this file
-        // is meant to be applied to the app via the Amplify Console, the AWS
-        // CLI, or an `amplify.yml` postBuild step. See the README "Redirects"
-        // section for the full deployment workflow.
+        // customRules format, then append any user-supplied rules from the
+        // `customRules` adapter option verbatim. Amplify Hosting does not
+        // auto-discover redirect rules from a build artifact the way
+        // Vercel/Netlify do, so this file is meant to be applied to the app
+        // via the Amplify Console, the AWS CLI, or an `amplify.yml`
+        // postBuild step. See the README "Redirects" section for the full
+        // deployment workflow.
         //
-        // Skipped when there are no redirects so builds don't emit an empty
+        // Skipped when both lists are empty so builds don't emit an empty
         // config alongside the rest of the artifact tree.
-        const customRules = buildCustomRules(
+        const generatedRules = buildCustomRules(
           _routes,
           _config.base,
           _config.trailingSlash,
           logger,
         );
-        if (customRules.length > 0) {
+        const extraRules = options.customRules ?? [];
+        const allRules = [...generatedRules, ...extraRules];
+
+        if (allRules.length > 0) {
           await writeFile(
             join(amplifyHostingDir, "customRules.json"),
-            JSON.stringify(customRules, null, 2) + "\n",
+            JSON.stringify(allRules, null, 2) + "\n",
           );
+
+          const parts: string[] = [];
+          if (generatedRules.length > 0) {
+            parts.push(`${generatedRules.length} from redirects`);
+          }
+          if (extraRules.length > 0) {
+            parts.push(`${extraRules.length} from customRules`);
+          }
           logger.info(
-            `Generated ${customRules.length} Amplify custom rule${
-              customRules.length === 1 ? "" : "s"
-            } → .amplify-hosting/customRules.json`,
+            `Wrote ${allRules.length} Amplify rule${
+              allRules.length === 1 ? "" : "s"
+            } (${parts.join(", ")}) → .amplify-hosting/customRules.json`,
           );
         }
       },

--- a/packages/astro-aws-amplify/src/redirects.ts
+++ b/packages/astro-aws-amplify/src/redirects.ts
@@ -101,15 +101,22 @@ function isAbsoluteUrl(value: string): boolean {
  * falls back to SSR.
  *
  * Skipped for:
+ *   - URLs with a query string or fragment (`?` / `#`) — the trailing-slash
+ *     convention only applies to the path portion of a URL
  *   - the root `/` (always canonical)
  *   - paths ending in `<*>` — Amplify's wildcard is greedy and matches both
  *     `/blog/foo` and `/blog/foo/` from a single rule
  *   - paths ending in a file-extension-like suffix (e.g. `/sitemap.xml`)
  */
 function applyTrailingSlash(path: string, mode: TrailingSlashMode): string {
+  // Query strings and fragments aren't part of the path — leave them alone
+  // rather than producing broken targets like `/foo/?bar=1/`.
+  if (/[?#]/.test(path)) return path;
+
   if (path === "/" || path.endsWith("<*>") || /\.[a-z0-9]+$/i.test(path)) {
     return path;
   }
+
   if (mode === "always" && !path.endsWith("/")) return `${path}/`;
   if (mode === "never" && path.endsWith("/")) return path.slice(0, -1);
   return path;

--- a/packages/astro-aws-amplify/src/redirects.ts
+++ b/packages/astro-aws-amplify/src/redirects.ts
@@ -1,0 +1,249 @@
+import type {
+  AstroConfig,
+  AstroIntegrationLogger,
+  IntegrationResolvedRoute,
+  ValidRedirectStatus,
+} from "astro";
+
+type TrailingSlashMode = AstroConfig["trailingSlash"];
+
+/**
+ * A single entry in AWS Amplify's "Rewrites and redirects" rule list.
+ *
+ * Matches the `CustomRule` shape consumed by `aws amplify update-app
+ * --custom-rules` (verified against `@aws-sdk/client-amplify`'s
+ * `CustomRule` type).
+ *
+ * @see https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html
+ */
+export interface AmplifyCustomRule {
+  /** Path pattern to match against the incoming request. */
+  source: string;
+  /** Destination path or URL. Wildcards from `source` are substituted positionally. */
+  target: string;
+  /** Status string accepted by Amplify's `customRules` API. */
+  status: AmplifyRedirectStatus;
+  /** Optional Amplify match condition (country code, etc.). */
+  condition?: string;
+}
+
+/**
+ * Status values accepted by Amplify's `customRules` API.
+ *
+ * - `"200"` — rewrite (URL stays the same in the browser)
+ * - `"301"` — permanent redirect
+ * - `"302"` — temporary redirect
+ * - `"404"` — not found
+ * - `"404-200"` — single-page-app fallback (rewrite missing routes to a 200 page)
+ */
+export type AmplifyRedirectStatus = "200" | "301" | "302" | "404" | "404-200";
+
+/**
+ * Astro supports a wider set of redirect status codes than Amplify exposes
+ * through `customRules`. Codes outside this map are skipped with a warning;
+ * codes that map to a different number (303/307/308) are emitted but logged
+ * so the user knows the precise HTTP semantics will shift.
+ */
+const ASTRO_TO_AMPLIFY_STATUS: Partial<
+  Record<ValidRedirectStatus, AmplifyRedirectStatus>
+> = {
+  301: "301",
+  302: "302",
+  303: "302",
+  307: "302",
+  308: "301",
+};
+
+/** Astro statuses that map to Amplify with no semantic loss. */
+const EXACT_STATUS_CODES = new Set<ValidRedirectStatus>([301, 302]);
+
+/**
+ * Prepend the site's base path to a route, normalizing the slash between them.
+ *
+ * Astro normalizes `config.base` to always start with `/` but the trailing
+ * slash depends on the user's `trailingSlash` setting (`"always"` → `"/docs/"`,
+ * otherwise → `"/docs"`). `IntegrationResolvedRoute.pattern` is NOT base-
+ * prefixed — it's relative to the configured base — so we prepend it ourselves
+ * to keep redirects matching at the Amplify edge.
+ *
+ * @example
+ *   joinBase("/", "/old")        // "/old"
+ *   joinBase("/docs", "/old")    // "/docs/old"
+ *   joinBase("/docs/", "/old")   // "/docs/old"
+ *   joinBase("/docs", "")        // "/docs/"   (empty path resolves to base root)
+ */
+export function joinBase(base: string, path: string): string {
+  if (!base || base === "/") return path;
+  const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const rootedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmedBase}${rootedPath}`;
+}
+
+/**
+ * Whether a redirect destination points at a different origin and so must
+ * not be base-prefixed.
+ *
+ * Matches any URI with a scheme (`https://`, `mailto:`, `tel:`, …) and
+ * protocol-relative URLs (`//cdn.example.com`). Anything else is treated as
+ * a same-origin path.
+ */
+function isAbsoluteUrl(value: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(value);
+}
+
+/**
+ * Bring a generated path into line with the user's `trailingSlash` setting.
+ *
+ * Astro reports route patterns without a trailing slash regardless of the
+ * configured mode, so an `astro.config.mjs` redirect like `/old → /new` would
+ * emit `source: "/old"` even when canonical URLs are `/old/`. Without this
+ * normalization the edge rule misses the canonical request and the redirect
+ * falls back to SSR.
+ *
+ * Skipped for:
+ *   - the root `/` (always canonical)
+ *   - paths ending in `<*>` — Amplify's wildcard is greedy and matches both
+ *     `/blog/foo` and `/blog/foo/` from a single rule
+ *   - paths ending in a file-extension-like suffix (e.g. `/sitemap.xml`)
+ */
+function applyTrailingSlash(path: string, mode: TrailingSlashMode): string {
+  if (path === "/" || path.endsWith("<*>") || /\.[a-z0-9]+$/i.test(path)) {
+    return path;
+  }
+  if (mode === "always" && !path.endsWith("/")) return `${path}/`;
+  if (mode === "never" && path.endsWith("/")) return path.slice(0, -1);
+  return path;
+}
+
+/**
+ * Convert an Astro route pattern to the placeholder syntax Amplify expects.
+ *
+ * Astro uses `[param]` for a single dynamic segment and `[...rest]` for a
+ * catch-all spread. Amplify supports two distinct constructs:
+ *
+ *   - Named placeholders `<name>` — multiple are allowed in a single rule and
+ *     are substituted by name into the target (the AWS "Placeholders" pattern).
+ *   - The greedy wildcard `<*>` — must be unique per rule and must appear at
+ *     the end of the source, or Amplify silently ignores the rule.
+ *
+ * Astro's syntax maps cleanly onto these:
+ *
+ *   - `[param]` → `<param>` (named placeholder)
+ *   - `[...spread]` → `<*>` (greedy wildcard; Astro only allows spread as the
+ *     trailing segment, which satisfies Amplify's "must be at end" rule)
+ *
+ * @example
+ *   astroPatternToAmplify("/blog/[id]")             // "/blog/<id>"
+ *   astroPatternToAmplify("/docs/[...slug]")        // "/docs/<*>"
+ *   astroPatternToAmplify("/site/[lang]/[...slug]") // "/site/<lang>/<*>"
+ *   astroPatternToAmplify("/old/[a]/[b]")           // "/old/<a>/<b>"
+ *   astroPatternToAmplify("/old-page")              // "/old-page"
+ */
+export function astroPatternToAmplify(pattern: string): string {
+  return pattern
+    .replace(/\[\.{3}[^\]]+\]/g, "<*>")
+    .replace(/\[([^\]]+)\]/g, "<$1>");
+}
+
+/**
+ * Comparator key for sorting rules from most specific to most generic.
+ *
+ * Amplify evaluates `customRules` in declaration order, so the more specific
+ * rule has to come first. We compare by:
+ *   1. Dynamic-segment count, ascending (fewer dynamic segments is more
+ *      specific). Both named placeholders (`<name>`) and the greedy wildcard
+ *      (`<*>`) count.
+ *   2. Source length, descending (longer literal prefix wins ties).
+ *
+ * Lower tuple values sort earlier — i.e., are more specific.
+ */
+function specificityKey(source: string): [number, number] {
+  const dynamicCount = (source.match(/<[^>]+>/g) ?? []).length;
+  return [dynamicCount, -source.length];
+}
+
+/**
+ * Convert a single Astro redirect route into an Amplify custom rule.
+ *
+ * Returns `null` for routes that aren't of type `"redirect"`, for redirects
+ * with an unsupported status code, or for malformed entries — so callers can
+ * `map`+`filter` over the full route list without pre-checking.
+ */
+export function buildCustomRule(
+  route: IntegrationResolvedRoute,
+  base: string,
+  trailingSlash: TrailingSlashMode,
+  logger?: AstroIntegrationLogger,
+): AmplifyCustomRule | null {
+  if (route.type !== "redirect") return null;
+
+  const config = route.redirect;
+  if (!config) {
+    logger?.warn(
+      `Route "${route.pattern}" is typed as "redirect" but has no destination; skipping.`,
+    );
+    return null;
+  }
+
+  const destination = typeof config === "string" ? config : config.destination;
+  const astroStatus: ValidRedirectStatus =
+    typeof config === "string" ? 301 : config.status;
+
+  const status = ASTRO_TO_AMPLIFY_STATUS[astroStatus];
+  if (!status) {
+    logger?.warn(
+      `Astro redirect status ${astroStatus} is not supported by AWS Amplify ` +
+        `customRules. Skipping route "${route.pattern}" → "${destination}".`,
+    );
+    return null;
+  }
+
+  if (!EXACT_STATUS_CODES.has(astroStatus)) {
+    logger?.warn(
+      `Astro redirect status ${astroStatus} has no exact Amplify equivalent; ` +
+        `emitting "${status}" for "${route.pattern}" → "${destination}". ` +
+        `If you depend on the precise HTTP semantics of ${astroStatus}, set ` +
+        `the rule manually in the Amplify Console.`,
+    );
+  }
+
+  const source = applyTrailingSlash(
+    astroPatternToAmplify(joinBase(base, route.pattern)),
+    trailingSlash,
+  );
+  // Cross-origin destinations are emitted verbatim; only same-origin paths
+  // get the base-path and trailing-slash treatments.
+  const target = isAbsoluteUrl(destination)
+    ? destination
+    : applyTrailingSlash(
+        astroPatternToAmplify(joinBase(base, destination)),
+        trailingSlash,
+      );
+
+  return { source, target, status };
+}
+
+/**
+ * Build the Amplify customRules payload from the resolved Astro routes.
+ *
+ * The result is sorted from most specific to most generic so that catch-all
+ * patterns can't shadow specific rules at evaluation time.
+ */
+export function buildCustomRules(
+  routes: IntegrationResolvedRoute[],
+  base: string,
+  trailingSlash: TrailingSlashMode,
+  logger?: AstroIntegrationLogger,
+): AmplifyCustomRule[] {
+  const rules = routes
+    .map((route) => buildCustomRule(route, base, trailingSlash, logger))
+    .filter((rule): rule is AmplifyCustomRule => rule !== null);
+
+  rules.sort((a, b) => {
+    const [aw, al] = specificityKey(a.source);
+    const [bw, bl] = specificityKey(b.source);
+    return aw !== bw ? aw - bw : al - bl;
+  });
+
+  return rules;
+}


### PR DESCRIPTION
Hello @alexnguyennz 👋

Here's a PR adding support for redirects by translating the `redirects` field from `astro.config.mjs` into `.amplify-hosting/customRules.json` at build time, matching the format AWS Amplify expects.

This is similar to what the [@astrojs/vercel](https://www.npmjs.com/package/@astrojs/vercel) and [@astrojs/netlify](https://www.npmjs.com/package/@astrojs/netlify) adapters do, which both translate redirects into platform-native configuration.

Amplify Hosting doesn't auto-discover redirect rules from the build output, so the README documents three ways to apply the generated file:

- manually in the Amplify Console
- with the `aws amplify update-app` CLI command
- as an `amplify.yml` postBuild step

## Supported features

The adapter respects both Astro's `base` and `trailingSlash` options. If your site uses a base path, `source` and `target` are automatically prefixed. Trailing slashes are then added (`always`), stripped (`never`), or left alone (`ignore`, the default) to match your setting. Wildcard endings and file-extension paths are skipped.

Absolute URL targets (`https://...`, `http://...`, `//host/...`) are preserved as-is. Neither the base prefix nor the trailing-slash treatment is applied to them.

Rules are sorted by specificity so catch-alls can't shadow specific routes. Fewer dynamic segments come first, and longer literal prefixes break ties.

The rule-building helpers are also exported from `astro-aws-amplify/redirects`, in case you want to build the same `customRules.json` from sources other than `astro.config.mjs` (like a CMS).

## Mapping

Per the [AWS docs on wildcards](https://docs.aws.amazon.com/amplify/latest/userguide/redirect-rewrite-examples.html#wildcard-redirects):

| Astro | Amplify | |
| --- | --- | --- |
| `[param]` | `<param>` | named placeholder, multiple per rule allowed |
| `[...spread]` | `<*>` | wildcard, must be unique and at the end of the source |

So `/old/[a]/[b]` becomes `/old/<a>/<b>`, not `/old/<*>/<*>` (which Amplify silently ignores).

Amplify only supports `301` and `302` as redirect statuses ([docs](https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#types-of-redirects)), so Astro's other codes are mapped as follows:

| Astro | Amplify |
| --- | --- |
| `301` | `301` |
| `302` | `302` |
| `303` | `302` |
| `307` | `302` |
| `308` | `301` |

`303`, `307`, and `308` emit a warning log at build time so the change is visible. Unknown status codes are also skipped with a warning.

## Custom rules

For anything that isn't a redirect, the adapter exposes a `customRules` option that takes Amplify's "Rewrites and redirects" rules directly:

```js
adapter: awsAmplify({
  customRules: [
    { source: "/images/<*>", target: "https://images.example.com/<*>", status: "200" },
    { source: "/<a>/", target: "/<a>/index.html", status: "200" },
  ],
}),
```

These are appended to `customRules.json` verbatim, after the generated redirects. The ordering means a specific redirect from `astro.config.mjs` can't be shadowed by a generic catch-all rewrite declared here.

This also covers the rewrites currently described in the README's "Static or prerendered pages" Limitations section — they can now be declared in `astro.config.mjs` rather than configured manually in the Amplify Console. That section has been updated to recommend the new approach.

## Testing

```sh
pnpm install
cd demos/base-path && pnpm run build
cat .amplify-hosting/customRules.json
```

Expected:

```json
[
  { "source": "/base/old-page/", "target": "/base/new-page/", "status": "301" },
  { "source": "/base/blog/<slug>/", "target": "/base/posts/<slug>/", "status": "302" }
]
```

## Compatibility

No breaking changes, builds without a `redirects` config behave exactly as before, with no new file created in the build artifact.

Please let me know if you have any comments or feedback! 🙏