### PR TITLE
feat: autogenerate rewrites for prerendered pages

### DIFF
--- a/packages/astro-aws-amplify/README.md
+++ b/packages/astro-aws-amplify/README.md
@@ -271,7 +271,7 @@ export default defineConfig({
     customRules: [
       // Reverse proxy — serve another origin's content under the same URL.
       { source: "/images/<*>", target: "https://images.example.com/<*>", status: "200" },
-      // SPA-style fallback for prerendered directory pages.
+      // SPA-style fallback for unmatched paths.
       { source: "/<a>/", target: "/<a>/index.html", status: "200" },
     ],
   }),
@@ -299,6 +299,7 @@ const rules: AmplifyCustomRule[] = [
 - image optimization with [`<Image>`](https://docs.astro.build/en/guides/images/#image--astroassets) and [`<Picture />`](https://docs.astro.build/en/guides/images/#picture-)
 - [base paths](https://docs.astro.build/en/reference/configuration-reference/#base)
 - [middleware](https://docs.astro.build/en/guides/middleware/)
+- [prerendered pages](#static-or-prerendered-pages) — rewrite rules auto-generated for every static/prerendered page
 - [redirects](#redirects) — auto-generated `customRules.json` from `astro.config.mjs`
 - [custom rules](#custom-rules) — pass Amplify rewrites, proxies, and 404 fallbacks through the adapter
 
@@ -311,48 +312,16 @@ const rules: AmplifyCustomRule[] = [
 
 ### Static or prerendered pages
 
-Static or prerendered pages (defined with `export const prerender = true`, or all pages when using `output: "static"`) need a rewrite rule, since Amplify routes those paths to the SSR compute by default.
+Static or prerendered pages (defined with `export const prerender = true`, or all pages when using `output: "static"`) get a rewrite rule generated automatically — the adapter emits a `status: "200"` entry in `customRules.json` for each prerendered page, routing the request directly to the static file instead of through SSR compute.
 
-The cleanest option is to declare these through the adapter's [`customRules`](#custom-rules) option, which keeps them in `astro.config.mjs` alongside the rest of your config:
-
-```js
-adapter: awsAmplify({
-  customRules: [
-    // Static page
-    { source: "/about/", target: "/about/index.html", status: "200" },
-    // Static dynamic route (e.g. /blog/[slug].astro)
-    { source: "/blog/<slug>/", target: "/blog/<slug>/index.html", status: "200" },
-  ],
-}),
-```
-
-Adjust the trailing slash on `source` and `target` to match your [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) setting — drop it for `"never"`, keep it for `"always"` and the default `"ignore"`. For sites served under a `base`, prefix accordingly (`/base/about/` → `/base/about/index.html`). Like every other entry in `customRules`, you'll need to [apply the generated file](#apply-the-rules-to-your-amplify-app) to your Amplify app for these rewrites to take effect.
-
-The other option is to set up the same rules manually in the Amplify Console under **Hosting → Rewrites and redirects** — useful if you'd rather not put them in your Astro config or already manage Amplify rules outside of code.
-
-For example, if you have a static `/about` page, create a rewrite of:
-
+For example, a page at `/about/` produces:
 ```
 /about/ /about/index.html 200 (Rewrite)
 ```
 
-If you don't use [trailing slashes](https://docs.astro.build/en/reference/configuration-reference/#trailingslash), you will need to also add:
+Dynamic routes preserve their placeholders (`/blog/[slug].astro` → `/blog/<slug> /blog/<slug>/index.html`), catch-all spreads use `<*>`, file-extension pages (like `/rss.xml`) pass through with source and target identical, and the `base` path and `trailingSlash` settings are respected throughout.
 
-```
-/about /about/index.html 200 (Rewrite)
-```
-
-For static dynamic routes, like a route of `/blog/[slug].astro`, create a rewrite of:
-
-```
-/blog/<slug>/ /blog/<slug>/index.html 200 (Rewrite)
-```
-
-For sites served under a `base`:
-
-```
-/base/about/ /base/about/index.html 200 (Rewrite)
-```
+You can still override a prerender rewrite by declaring a matching rule in `customRules` — user-supplied rules are appended after auto-generated ones and take precedence by ordering.
 
 ### 404 Pages
 Custom 404 pages (like `404.astro`) need to be server-side rendered (not prerendered) to work. This is a [limitation with Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-deployment-specification.html#catchall-fallback-routing).

--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { AmplifyCustomRule } from "./redirects.js";
-import { buildCustomRules } from "./redirects.js";
+import { buildCustomRules, buildPrerenderRewrites } from "./redirects.js";
 
 export type {
   AmplifyCustomRule,
@@ -131,24 +131,39 @@ export default function awsAmplify(
         );
 
         // Translate `redirects` from astro.config.mjs into Amplify's
-        // customRules format, then append any user-supplied rules from the
-        // `customRules` adapter option verbatim. Amplify Hosting does not
-        // auto-discover redirect rules from a build artifact the way
-        // Vercel/Netlify do, so this file is meant to be applied to the app
-        // via the Amplify Console, the AWS CLI, or an `amplify.yml`
-        // postBuild step. See the README "Redirects" section for the full
-        // deployment workflow.
+        // customRules format, then generate rewrite rules for prerendered
+        // pages, and finally append any user-supplied rules from the
+        // `customRules` adapter option verbatim.
         //
-        // Skipped when both lists are empty so builds don't emit an empty
-        // config alongside the rest of the artifact tree.
+        // Prerender rewrites live between redirects and user custom rules so
+        // that explicit redirects take priority over static-file rewrites,
+        // while user-provided catch-alls (e.g. SPA fallback) come last.
+        //
+        // Amplify Hosting does not auto-discover redirect rules from a build
+        // artifact the way Vercel/Netlify do, so this file is meant to be
+        // applied to the app via the Amplify Console, the AWS CLI, or an
+        // `amplify.yml` postBuild step. See the README "Redirects" section
+        // for the full deployment workflow.
+        //
+        // Skipped when all three lists are empty so builds don't emit an
+        // empty config alongside the rest of the artifact tree.
         const generatedRules = buildCustomRules(
           _routes,
           _config.base,
           _config.trailingSlash,
           logger,
         );
+        const prerenderRewrites = buildPrerenderRewrites(
+          _routes,
+          _config.base,
+          _config.trailingSlash,
+        );
         const extraRules = options.customRules ?? [];
-        const allRules = [...generatedRules, ...extraRules];
+        const allRules = [
+          ...generatedRules,
+          ...prerenderRewrites,
+          ...extraRules,
+        ];
 
         if (allRules.length > 0) {
           await writeFile(
@@ -159,6 +174,9 @@ export default function awsAmplify(
           const parts: string[] = [];
           if (generatedRules.length > 0) {
             parts.push(`${generatedRules.length} from redirects`);
+          }
+          if (prerenderRewrites.length > 0) {
+            parts.push(`${prerenderRewrites.length} from prerendered pages`);
           }
           if (extraRules.length > 0) {
             parts.push(`${extraRules.length} from customRules`);

--- a/packages/astro-aws-amplify/src/redirects.ts
+++ b/packages/astro-aws-amplify/src/redirects.ts
@@ -231,6 +231,60 @@ export function buildCustomRule(
 }
 
 /**
+ * Convert a single Astro prerendered page route into an Amplify rewrite rule.
+ *
+ * Returns `null` for routes that aren't prerendered pages (i.e. routes that
+ * will be handled by SSR at runtime).
+ *
+ * For a page at `/about/`, the generated rule rewrites the request to
+ * `/about/index.html` in Amplify's static file storage, bypassing the SSR
+ * compute entirely. For a file-extension page like `/rss.xml`, the source
+ * and target are identical since the file has no extra directory wrapper.
+ */
+export function buildPrerenderRewriteRule(
+  route: IntegrationResolvedRoute,
+  base: string,
+  trailingSlash: TrailingSlashMode,
+): AmplifyCustomRule | null {
+  if (route.type !== "page" || !route.isPrerendered) return null;
+
+  const amplifyPattern = astroPatternToAmplify(joinBase(base, route.pattern));
+  const source = applyTrailingSlash(amplifyPattern, trailingSlash);
+
+  const hasFileExtension = /\.[a-z0-9]+$/i.test(route.pattern);
+  const target = hasFileExtension
+    ? source
+    : applyTrailingSlash(amplifyPattern + "/index.html", trailingSlash);
+
+  // sanitize base path so "/" is just "/index.html" and not "//index.html"
+  return { source, target: target.replace("//", "/"), status: "200" };
+}
+
+/**
+ * Build Amplify rewrite rules for all prerendered pages in the route list.
+ *
+ * The result is sorted from most specific to most generic so that catch-all
+ * patterns can't shadow specific rules at evaluation time.
+ */
+export function buildPrerenderRewrites(
+  routes: IntegrationResolvedRoute[],
+  base: string,
+  trailingSlash: TrailingSlashMode,
+): AmplifyCustomRule[] {
+  const rules = routes
+    .map((route) => buildPrerenderRewriteRule(route, base, trailingSlash))
+    .filter((rule): rule is AmplifyCustomRule => rule !== null);
+
+  rules.sort((a, b) => {
+    const [aw, al] = specificityKey(a.source);
+    const [bw, bl] = specificityKey(b.source);
+    return aw !== bw ? aw - bw : al - bl;
+  });
+
+  return rules;
+}
+
+/**
  * Build the Amplify customRules payload from the resolved Astro routes.
  *
  * The result is sorted from most specific to most generic so that catch-all


### PR DESCRIPTION
## Summary

Autogenerates redirects in `customRules.json` for prerendered pages.

## Context

I'm working on an Astro site hosted on AWS Amplify where the pages are all prerendered (i.e. `output: "static"`), except for one page, a lambda function, where `export const prerender = false;` is set.

According to the Limitations section of the README, I would need to create a rewrite rule for every page. Obviously, this is brittle and time consuming.

This PR fixes that by auto generating a `customRules.json` for all prerendered pages.

## Note

This works for my project via a patch, but I'm sure there are potential edge cases where it doesn't work (maybe with a `base` set?), so any feedback is appreciated.

---

Also, thanks for this great adapter!