### PR TITLE
fix: support Astro 6.3.0+ adapterLogger getter while keeping backward compatibility

### DIFF
--- a/demos/base-path/CHANGELOG.md
+++ b/demos/base-path/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies []:
+  - astro-aws-amplify@0.4.1
+
+## 0.0.13
+
+### Patch Changes
+
 - Upgrade to Astro 6, migrate content collections to Content Layer API
 - Updated dependencies:
   - astro-aws-amplify@0.3.0

--- a/demos/base-path/package.json
+++ b/demos/base-path/package.json
@@ -2,7 +2,7 @@
   "name": "base-path",
   "type": "module",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/demos/server/CHANGELOG.md
+++ b/demos/server/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies []:
+  - astro-aws-amplify@0.4.1
+
+## 0.0.13
+
+### Patch Changes
+
 - Upgrade to Astro 6, migrate content collections to Content Layer API
 - Renamed from `blog` to `server` to reflect `output: "server"` mode
 - Updated dependencies:

--- a/demos/server/package.json
+++ b/demos/server/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "type": "module",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/demos/static/CHANGELOG.md
+++ b/demos/static/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies []:
+  - astro-aws-amplify@0.4.1
+
+## 0.0.13
+
+### Patch Changes
+
 - Upgrade to Astro 6, migrate content collections to Content Layer API
 - Renamed from `hybrid` to `static` to reflect `output: "static"` mode (`output: "hybrid"` was removed in Astro 6)
 - Updated dependencies:

--- a/demos/static/package.json
+++ b/demos/static/package.json
@@ -2,7 +2,7 @@
   "name": "static",
   "type": "module",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/astro-aws-amplify/CHANGELOG.md
+++ b/packages/astro-aws-amplify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # astro-aws-amplify
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix compatibility with Astro 6.3.0+ where `getAdapterLogger()` was renamed to `adapterLogger` getter property
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/astro-aws-amplify/package.json
+++ b/packages/astro-aws-amplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-aws-amplify",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "description": "Deploy Astro to AWS Amplify (SSR)",
   "keywords": [

--- a/packages/astro-aws-amplify/src/server.ts
+++ b/packages/astro-aws-amplify/src/server.ts
@@ -29,7 +29,7 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 const app = createApp();
-const logger = app.getAdapterLogger();
+const logger = "adapterLogger" in app ? app.adapterLogger : app.getAdapterLogger();
 const port = Number(process.env.PORT) || 3000;
 const host = process.env.HOST || "0.0.0.0";
 


### PR DESCRIPTION
Astro 6.3.0 renamed `getAdapterLogger()` method to an `adapterLogger` getter property (PR #16366). This broke deployments on Amplify with `TypeError: app.getAdapterLogger is not a function`.

This change detects which API is available at runtime, maintaining compatibility with both Astro 6.0.0-6.2.x and 6.3.0+.