### PR TITLE
feat: add runtimeEnv option for propagating env vars to the Lambda runtime

### DIFF
--- a/.changeset/plenty-apes-brush.md
+++ b/.changeset/plenty-apes-brush.md
@@ -1,5 +1,0 @@
----
-"astro-aws-amplify": minor
----
-
-Add runtimeEnv option that lists environment variables to propagate from the build to the Lambda runtime. Adapter writes them as a .env file next to entry.mjs, which server.ts already loads at cold start via process.loadEnvFile(). Missing variables emit a warning at build time and are skipped instead of writing empty KEY= lines.

--- a/.changeset/plenty-apes-brush.md
+++ b/.changeset/plenty-apes-brush.md
@@ -1,0 +1,5 @@
+---
+"astro-aws-amplify": minor
+---
+
+Add runtimeEnv option that lists environment variables to propagate from the build to the Lambda runtime. Adapter writes them as a .env file next to entry.mjs, which server.ts already loads at cold start via process.loadEnvFile(). Missing variables emit a warning at build time and are skipped instead of writing empty KEY= lines.

--- a/demos/base-path/CHANGELOG.md
+++ b/demos/base-path/CHANGELOG.md
@@ -1,5 +1,12 @@
 # base-path
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies [[`c6b3511`](https://github.com/alexnguyennz/astro-aws-amplify/commit/c6b35117fbf60cc0e1ea0bc8d4841be5d7469052)]:
+  - astro-aws-amplify@0.6.0
+
 ## 0.0.13
 
 ### Patch Changes

--- a/demos/base-path/package.json
+++ b/demos/base-path/package.json
@@ -2,7 +2,7 @@
   "name": "base-path",
   "type": "module",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/demos/server/CHANGELOG.md
+++ b/demos/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # server
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies [[`c6b3511`](https://github.com/alexnguyennz/astro-aws-amplify/commit/c6b35117fbf60cc0e1ea0bc8d4841be5d7469052)]:
+  - astro-aws-amplify@0.6.0
+
 ## 0.0.13
 
 ### Patch Changes

--- a/demos/server/package.json
+++ b/demos/server/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "type": "module",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/demos/static/CHANGELOG.md
+++ b/demos/static/CHANGELOG.md
@@ -1,5 +1,12 @@
 # static
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies [[`c6b3511`](https://github.com/alexnguyennz/astro-aws-amplify/commit/c6b35117fbf60cc0e1ea0bc8d4841be5d7469052)]:
+  - astro-aws-amplify@0.6.0
+
 ## 0.0.13
 
 ### Patch Changes

--- a/demos/static/package.json
+++ b/demos/static/package.json
@@ -2,7 +2,7 @@
   "name": "static",
   "type": "module",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/astro-aws-amplify/CHANGELOG.md
+++ b/packages/astro-aws-amplify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # astro-aws-amplify
 
+## 0.6.0
+
+### Minor Changes
+
+- [`c6b3511`](https://github.com/alexnguyennz/astro-aws-amplify/commit/c6b35117fbf60cc0e1ea0bc8d4841be5d7469052) Thanks [@KabraX](https://github.com/KabraX)! - Add runtimeEnv option that lists environment variables to propagate from the build to the Lambda runtime. Adapter writes them as a .env file next to entry.mjs, which server.ts already loads at cold start via process.loadEnvFile(). Missing variables emit a warning at build time and are skipped instead of writing empty KEY= lines.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/astro-aws-amplify/package.json
+++ b/packages/astro-aws-amplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-aws-amplify",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "Deploy Astro to AWS Amplify (SSR)",
   "keywords": [

--- a/packages/astro-aws-amplify/src/index.ts
+++ b/packages/astro-aws-amplify/src/index.ts
@@ -43,6 +43,29 @@ export interface AwsAmplifyOptions {
    * here won't shadow a specific redirect from `astro.config.mjs`.
    */
   customRules?: AmplifyCustomRule[];
+
+  /**
+   * Names of environment variables to propagate from the build environment
+   * to the Lambda runtime. They are written as a `.env` file next to
+   * `entry.mjs`, which `server.ts` loads at cold start via
+   * `process.loadEnvFile()`.
+   *
+   * AWS Amplify Hosting injects environment variables into the build
+   * environment (CodeBuild) but does not automatically expose them to the
+   * Lambda compute. This option closes the gap so users don't have to
+   * `echo "X=$X" >> .env && mv .env ./.amplify-hosting/compute/default/`
+   * in `amplify.yml`.
+   *
+   * Values are read from `process.env` at build time. Missing variables
+   * emit a warning at build time and are skipped — no empty `KEY=` lines
+   * are written.
+   *
+   * @example
+   *   awsAmplify({
+   *     runtimeEnv: ["STRIPE_SECRET_KEY", "DATABASE_URL"],
+   *   })
+   */
+  runtimeEnv?: string[];
 }
 
 export default function awsAmplify(
@@ -183,6 +206,58 @@ export default function awsAmplify(
               allRules.length === 1 ? "" : "s"
             } (${parts.join(", ")}) → .amplify-hosting/customRules.json`,
           );
+        }
+
+        // Propagate selected build-time environment variables to the
+        // Lambda runtime by writing them to a `.env` file next to
+        // entry.mjs. `server.ts` loads it via process.loadEnvFile() on
+        // cold start. See `runtimeEnv` in AwsAmplifyOptions for the
+        // rationale.
+        const runtimeEnvNames = options.runtimeEnv ?? [];
+        if (runtimeEnvNames.length > 0) {
+          const lines: string[] = [];
+          const missing: string[] = [];
+
+          for (const name of runtimeEnvNames) {
+            const value = process.env[name];
+            if (value === undefined || value === "") {
+              missing.push(name);
+              continue;
+            }
+            // Quote values containing whitespace, `=`, `#`, quotes, or
+            // newlines — characters dotenv parsing dislikes. Plain
+            // alphanumeric values (the common case for API keys, IDs,
+            // URLs without spaces) stay unquoted.
+            const needsQuoting = /[\n\r#"' =]/.test(value);
+            const escaped = needsQuoting
+              ? `"${value
+                  .replace(/\\/g, "\\\\")
+                  .replace(/"/g, '\\"')
+                  .replace(/\n/g, "\\n")}"`
+              : value;
+            lines.push(`${name}=${escaped}`);
+          }
+
+          if (missing.length > 0) {
+            logger.warn(
+              `runtimeEnv: ${missing.length} variable${
+                missing.length === 1 ? "" : "s"
+              } not set in build environment: ${missing.join(", ")}. ` +
+                `These will be unavailable in the Lambda runtime.`,
+            );
+          }
+
+          if (lines.length > 0) {
+            await writeFile(
+              join(amplifyHostingDir, "compute/default/.env"),
+              lines.join("\n") + "\n",
+            );
+            logger.info(
+              `Wrote ${lines.length} runtime env var${
+                lines.length === 1 ? "" : "s"
+              } → .amplify-hosting/compute/default/.env`,
+            );
+          }
         }
       },
     },


### PR DESCRIPTION
## Summary

Adds a new `runtimeEnv?: string[]` option to the adapter. When set, the adapter writes the listed environment variables — read from `process.env` at build time — into a `.env` file next to `entry.mjs`. `server.ts` already loads that file at cold start via `process.loadEnvFile()`, so the variables become available as `process.env.X` (and via `astro:env` for projects using `envField`) inside the Lambda runtime.

## Problem this is fixing

AWS Amplify Hosting injects environment variables defined in the Amplify Console into the build environment (CodeBuild). It does not propagate them to the Lambda compute at runtime. The adapter already declares `envGetSecret: "stable"` in `supportedAstroFeatures` and `server.ts` calls `process.loadEnvFile()` on cold start but nothing in the build pipeline actually writes the `.env` file that the loader expects.

The result is that any SSR route that reads a secret crashes with `undefined` until the user manually wires it up. The de-facto workaround today is something like this in `amplify.yml`:

```yaml
- echo "STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY" >> .env
- echo "DATABASE_URL=$DATABASE_URL" >> .env
- ... one line per variable ...
- pnpm run build
- mv .env ./.amplify-hosting/compute/default/.env
```

This is what bit my project (a corporate Astro site doing Stripe checkout through SSR API routes) on the first deploy: the build succeeded, the Lambda started, but every call to /api/stripe/checkout threw STRIPE_SECRET_KEY is not set
because there was no .env next to entry.mjs.

### How this PR fixes it

The user declares the variables they need at runtime in `astro.config.mjs`:

```astro
adapter: awsAmplify({
  runtimeEnv: [
    "STRIPE_SECRET_KEY",
    "STRIPE_PUBLISHABLE_KEY",
    "DATABASE_URL",
  ],
})
```

During `astro:build:done`, the adapter:

1. Reads each name from process.env.
2. Quotes any value containing whitespace, =, #, quotes, or newlines (plain alphanumeric values stay unquoted, which is the common case for API keys / IDs / URLs without spaces).
3. Writes the result to .amplify-hosting/compute/default/.env.
4. Emits an info log: Wrote N runtime env vars → .amplify-hosting/compute/default/.env.

Missing variables emit a build-time warning and are skipped instead of writing empty KEY= lines:

> runtimeEnv: 1 variable not set in build environment: STRIPE_SECRET_KEY. These will be unavailable in the Lambda runtime.

The amplify.yml collapses from a per-variable echo chain plus a final mv to just pnpm run build.

Design notes

- Opt-in: existing users see zero change in behaviour. The branch only runs when runtimeEnv is set. No file written, no extra logs.
- Empty values are treated as missing (undefined or "") so we don't ship KEY= lines that would override real values inside the Lambda.
- Quoting follows dotenv conventions: quote only when the value contains characters that would break pastrings cover \, ", and \n.
- Placement matches what server.ts already does: process.loadEnvFile() reads from the current working directory, and entry.mjs runs from compute/default/, so writing the file there means cold start finds it automatically. No changes to
server.ts needed.

## Test plan

### Prod

Validated in a production deployment of my project to AWS Amplify staging. The same code path (write a .env to compute/default/) was implemented locally as an Astro integration that runs in astro:build:done, with 7 env variables.

After deploy, the build log showed _Wrote 7 env vars → .amplify-hosting/compute/default/.env_, and hittin reads STRIPE_SECRET_KEY via import.meta.env) returned a Stripe Checkout session URL successfully. Confirms the end-to-end chain works: build writes file → Amplify packages it into the Lambda artifact → cold start loads it → application code reads process.env.X and works.

### Local

Tested against `demos/server` with Astro 6.1.5, Node 24.16.0, pnpm 10.33.0:

- **Without `runtimeEnv`** → unchanged behavior, no `.env` written.
- **With `runtimeEnv: ["TEST_VAR_1", "TEST_VAR_2", "MISSING_ON_PURPOSE"]`** and `TEST_VAR_1`/`TEST_VAR_2` set in the build env: the integration logs `Wrote 2 runtime env vars → .amplify-hosting/compute/default/.env`, the file contains exactly those two lines, and a separate warning lists `MISSING_ON_PURPOSE` as not set (no empty `KEY=` line is written).
- `tsc --noEmit` and `eslint` on the modified file are clean.

The same `.env`-next-to-`entry.mjs` pattern was independently validated in a real production deployment on Amplify staging in my own project, where SSR endpoints (Stripe checkout/portal) read the propagated secrets successfully on cold start.

## Environment used to author this PR

- Node 18.14.1 (the repo declares engines.node: ">=22.12.0"; pnpm i warned about this but completed clesc --noEmit and eslint on the modified file)
- pnpm 10.33.0 (matches engines.pnpm: ">=10.0.0")
- Astro ^6.0.0 per this repo's peer dependency. The production validation happened on an Astro 5.18.0 project using the same write pattern via a local AstroIntegration; the API surface added here is identical, so behaviour should match once the project upgrades.

Thanks for maintaining this adapter — it's been working great for my team once we got past the initial friction 💕.